### PR TITLE
feature : S3로 write하는 로직 추가

### DIFF
--- a/brickstudy_ingestion/dags/travel/naver_search_news.py
+++ b/brickstudy_ingestion/dags/travel/naver_search_news.py
@@ -19,7 +19,7 @@ def request_naver_api():
     target_platform = "news"
     query = "여행"
     client = NaverSearch(target_platform)
-    result = client.request_with_keword(query)
+    result = client.request_with_keyword(query)
     print(result)
 
 

--- a/brickstudy_ingestion/src/common/aws_s3_mime.py
+++ b/brickstudy_ingestion/src/common/aws_s3_mime.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+class MimeType(Enum):
+    JSON = 'application/json'
+    TEXT = 'text/plain'
+    HTML = 'text/html'
+    XML = 'application/xml'
+    JPEG = 'image/jpeg'
+    PNG = 'image/png'
+    PDF = 'application/pdf'
+    OCTET_STREAM = 'application/octet-stream'
+    ZIP = 'application/zip'
+
+EXTENSION_TO_MIME = {
+    'json': MimeType.JSON.value,
+    'txt': MimeType.TEXT.value,
+    'html': MimeType.HTML.value,
+    'xml': MimeType.XML.value,
+    'jpg': MimeType.JPEG.value,
+    'jpeg': MimeType.JPEG.value,
+    'png': MimeType.PNG.value,
+    'pdf': MimeType.PDF.value,
+    'bin': MimeType.OCTET_STREAM.value,
+    'zip': MimeType.ZIP.value
+}

--- a/brickstudy_ingestion/src/common/errorcode.py
+++ b/brickstudy_ingestion/src/common/errorcode.py
@@ -11,3 +11,8 @@ class Naver(Enum):
         "code": 401,
         "message": "확인되지 않은 오류입니다."
     }
+
+    LimitExceedError = {
+        "code": 429,
+        "message": "하루 요청 허용량을 초과했습니다."
+    }

--- a/brickstudy_ingestion/src/common/s3_uploader.py
+++ b/brickstudy_ingestion/src/common/s3_uploader.py
@@ -1,8 +1,9 @@
-import os, json
-from datetime import datetime
+import os
 from typing import Any
 
 import boto3
+
+from src.common.aws_s3_mime import EXTENSION_TO_MIME
 
 
 class S3Uploader:
@@ -14,6 +15,7 @@ class S3Uploader:
             self,
             bucket_name: str, 
             file_key: str,
+            data_type: str,
             data: Any
         )-> None:
 
@@ -26,6 +28,12 @@ class S3Uploader:
         s3.put_object(
             Bucket=bucket_name, 
             Key=file_key, 
-            Body=json.dumps(data),
-            ContentType='application/json'
+            Body=data,
+            ContentType=self.get_mime_type(data_type)
         )
+
+    @staticmethod
+    def get_mime_type(extension: str):
+        if extension not in EXTENSION_TO_MIME: 
+            raise ValueError("Unsupported file extension.")
+        return EXTENSION_TO_MIME.get(extension) 

--- a/brickstudy_ingestion/src/common/s3_uploader.py
+++ b/brickstudy_ingestion/src/common/s3_uploader.py
@@ -5,11 +5,12 @@ import boto3
 
 from src.common.aws_s3_mime import EXTENSION_TO_MIME
 
-
+#TODO s3 client object 생성자에서 받아서 초기화? is refactor needed?
 class S3Uploader:
     def __init__(self) -> None:
         self.aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID')
         self.aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
+        self.s3_client = None
 
     def write_s3(
             self,
@@ -19,13 +20,13 @@ class S3Uploader:
             data: Any
         )-> None:
 
-        s3 = boto3.client(
+        self.s3_client = boto3.client(
             "s3",
             aws_access_key_id=self.aws_access_key_id, 
-            aws_secret_access_key=self.ws_secret_access_key
+            aws_secret_access_key=self.aws_secret_access_key
         )
 
-        s3.put_object(
+        self.s3_client.put_object(
             Bucket=bucket_name, 
             Key=file_key, 
             Body=data,

--- a/brickstudy_ingestion/src/common/s3_uploader.py
+++ b/brickstudy_ingestion/src/common/s3_uploader.py
@@ -1,0 +1,31 @@
+import os, json
+from datetime import datetime
+from typing import Any
+
+import boto3
+
+
+class S3Uploader:
+    def __init__(self) -> None:
+        self.aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID')
+        self.aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
+
+    def write_s3(
+            self,
+            bucket_name: str, 
+            file_key: str,
+            data: Any
+        )-> None:
+
+        s3 = boto3.client(
+            "s3",
+            aws_access_key_id=self.aws_access_key_id, 
+            aws_secret_access_key=self.ws_secret_access_key
+        )
+
+        s3.put_object(
+            Bucket=bucket_name, 
+            Key=file_key, 
+            Body=json.dumps(data),
+            ContentType='application/json'
+        )

--- a/brickstudy_ingestion/src/naver/models.py
+++ b/brickstudy_ingestion/src/naver/models.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+@dataclass
+class NewsApiCharacterSchema:
+    title: str
+    originallink: str
+    link: str
+    description: str
+    pubDate: str
+
+
+@dataclass
+class NewsApiResponse:
+    lastBuildDate: str
+    total: int
+    start: int
+    display: int
+    items: NewsApiCharacterSchema
+
+    def __post_init__(self):
+        self.items = [NewsApiCharacterSchema(**x) for x in self.items]
+
+
+@dataclass
+class ApiParameters:
+    query: str
+    display: int = field(default=10)
+    start: int = field(default=1)
+    sort: Literal["sim", "date"] = field(default="sim")

--- a/brickstudy_ingestion/src/naver/naver_search.py
+++ b/brickstudy_ingestion/src/naver/naver_search.py
@@ -3,6 +3,7 @@ import json
 from . import client_id, client_secret
 from src.common.errorcode import Naver
 from src.common.exception import ExtractError
+from src.common.s3_uploader import S3Uploader
 
 
 class NaverSearch:
@@ -22,7 +23,7 @@ class NaverSearch:
             "X-Naver-Client-Secret": client_secret
         }
 
-    def request_with_keword(
+    def request_with_keyword(
             self,
             query: str,         # 검색어. UTF-8로 인코딩되어야 합니다.
             display: int = 1,   # 한 번에 표시할 검색 결과 개수(기본값: 10, 최댓값: 100)

--- a/brickstudy_ingestion/src/naver/naver_search.py
+++ b/brickstudy_ingestion/src/naver/naver_search.py
@@ -1,5 +1,5 @@
 import urllib.request
-import requests
+import json
 from . import client_id, client_secret
 from src.common.errorcode import Naver
 from src.common.exception import ExtractError
@@ -16,7 +16,7 @@ class NaverSearch:
             - target_platform: 검색 대상 플랫폼(blog, news, cafe, etc)
             - resp_format: api 응답 반환 포맷(json or xml)
         """
-        self.base_url = f"https://openapi.naver.com/v1/search/{target_platform}.{resp_format}"
+        self.base_url = f"https://openapi.naver.com/v1/search/{target_platform}.{resp_format}?query="
         self.headers = {
             "X-Naver-Client-Id": client_id,
             "X-Naver-Client-Secret": client_secret
@@ -30,9 +30,9 @@ class NaverSearch:
             sort: str = "sim"   # 검색 결과 정렬 방법 - sim: 정확도순으로 내림차순 정렬(기본값) - date: 날짜순으로 내림차순 정렬
     ) -> dict:
         try:
-            encText = urllib.parse.quote(query)
-            sub_url = f"&display={display}&start={start}&sort={sort}"
-            url = self.base_url + encText + sub_url
+            encQuery = urllib.parse.quote(query)
+            sub_url = f"&display={str(display)}&start={str(start)}&sort={sort}"
+            url = self.base_url + encQuery + sub_url
 
             request = urllib.request.Request(url, headers=self.headers)
             response = urllib.request.urlopen(request)
@@ -40,8 +40,8 @@ class NaverSearch:
             if resCode == 401:
                 raise ExtractError(**Naver.AuthError.value,
                                    log=response.json())
-            elif resCode == 200:
-                return response.read().decode('utf-8').items
+            if resCode == 200:
+                return json.loads(response.read().decode('utf-8'))
             
         except Exception as e:
             raise ExtractError(**Naver.UnknownError.value, log=str(e))

--- a/brickstudy_ingestion/src/naver/naver_search.py
+++ b/brickstudy_ingestion/src/naver/naver_search.py
@@ -25,7 +25,7 @@ class NaverSearch:
     def request_with_keyword(
             self,
             query: str,         # 검색어. UTF-8로 인코딩되어야 합니다.
-            display: int = 1,   # 한 번에 표시할 검색 결과 개수(기본값: 10, 최댓값: 100)
+            display: int = 10,   # 한 번에 표시할 검색 결과 개수(기본값: 10, 최댓값: 100)
             start: int = 1,     # 검색 시작 위치(기본값: 1, 최댓값: 1000)
             sort: str = "sim"   # 검색 결과 정렬 방법 - sim: 정확도순으로 내림차순 정렬(기본값) - date: 날짜순으로 내림차순 정렬
     ) -> dict:

--- a/brickstudy_ingestion/src/naver/naver_search.py
+++ b/brickstudy_ingestion/src/naver/naver_search.py
@@ -37,11 +37,14 @@ class NaverSearch:
             request = urllib.request.Request(url, headers=self.headers)
             response = urllib.request.urlopen(request)
             resCode = response.getcode()
-            if resCode == 401:
-                raise ExtractError(**Naver.AuthError.value,
-                                   log=response.json())
-            if resCode == 200:
-                return json.loads(response.read().decode('utf-8'))
+            result = json.loads(response.read().decode('utf-8'))
+
+            if resCode == 200: return result
+            else:
+                if resCode == 401: 
+                    raise ExtractError(**Naver.AuthError.value, log=result)
+                if resCode == 429:
+                    raise ExtractError(**Naver.LimitExceedError.value, log=result)
             
         except Exception as e:
             raise ExtractError(**Naver.UnknownError.value, log=str(e))

--- a/brickstudy_ingestion/src/naver/naver_search.py
+++ b/brickstudy_ingestion/src/naver/naver_search.py
@@ -3,7 +3,6 @@ import json
 from . import client_id, client_secret
 from src.common.errorcode import Naver
 from src.common.exception import ExtractError
-from src.common.s3_uploader import S3Uploader
 
 
 class NaverSearch:

--- a/brickstudy_ingestion/tests/naver/test_naver_search.py
+++ b/brickstudy_ingestion/tests/naver/test_naver_search.py
@@ -63,6 +63,16 @@ def test_naver_search_cannot_connect_client_with_invalid_secret_key():
         # assert result["log"]["errorCode"] == '024'
 
 
+def test_naver_search_exceed_daily_request_quota():
+    # given : 네이버 api request 할당량 초과 or 1초에 너무 많은 request
+    # then : errorcode 429
+    with pytest.raises(ExtractError):
+        client = NaverSearch(PLATFROM, RESPONSE_FORMAT)
+        for _ in range(25000):
+            result = client.request_with_keyword(QUERY)
+        assert result["message"] == Naver.LimitExceedError.value["message"]
+
+
 def test_naver_search_can_connect_to_aws():
     import json
     from datetime import datetime

--- a/brickstudy_ingestion/tests/naver/test_naver_search.py
+++ b/brickstudy_ingestion/tests/naver/test_naver_search.py
@@ -19,7 +19,7 @@ def test_nave_search_can_connect_client_with_valid():
 
     # when : Naver news api 요청
     client = NaverSearch(PLATFROM, RESPONSE_FORMAT)
-    result = client.request_with_keword(QUERY, DISPLAY, START, SORT)
+    result = client.request_with_keyword(QUERY, DISPLAY, START, SORT)
 
     # then : json 데이터 확인
     assert result["start"] == 1
@@ -41,7 +41,7 @@ def test_naver_search_cannot_connect_client_with_invalid_id():
     with pytest.raises(ExtractError):
         client = NaverSearch(PLATFROM, RESPONSE_FORMAT)
         client.headers["X-Naver-Client-Id"] = wrong_id
-        result = client.request_with_keword(QUERY, DISPLAY, START, SORT)
+        result = client.request_with_keyword(QUERY, DISPLAY, START, SORT)
 
         assert result["message"] == Naver.AuthError.value["message"]
         # assert result["log"]["errorMessage"] == 'NID AUTH Result Invalid (1000) : Authentication failed. (인증에 실패했습니다.)'
@@ -57,7 +57,7 @@ def test_naver_search_cannot_connect_client_with_invalid_secret_key():
     with pytest.raises(ExtractError):
         client = NaverSearch(PLATFROM, RESPONSE_FORMAT)
         client.headers["X-Naver-Client-Secret"] = wrong_secret
-        result = client.request_with_keword(QUERY, DISPLAY, START, SORT)
+        result = client.request_with_keyword(QUERY, DISPLAY, START, SORT)
 
         assert result["message"] == Naver.AuthError.value["message"]
         # assert result["log"]["errorMessage"] == 'NID AUTH Result Invalid (28) : Authentication failed. (인증에 실패했습니다.)'

--- a/brickstudy_ingestion/tests/naver/test_naver_search.py
+++ b/brickstudy_ingestion/tests/naver/test_naver_search.py
@@ -3,6 +3,7 @@ from src.common.errorcode import Naver
 from src.common.exception import ExtractError
 from src.naver.naver_search import NaverSearch
 from src.common.aws_s3_mime import EXTENSION_TO_MIME
+from src.common.s3_uploader import S3Uploader
 
 # Mock
 PLATFROM = "news"
@@ -64,52 +65,41 @@ def test_naver_search_cannot_connect_client_with_invalid_secret_key():
 
 
 def test_naver_search_can_connect_to_aws():
-    import os, json
+    import json
     from datetime import datetime
-    import boto3
 
     # given : valid s3 client id, password
-    aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID')
-    aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
-
     # when : request that trying to connect aws
     # then : task success
     data = {'lastBuildDate': 'Sun, 21 Jul 2024 21:14:41 +0900', 'total': 5414727, 'start': 1, 'display': 1, 'items': [{'title': '[단독]한전, 건설지역서 10년간 선심성 식사·<b>여행</b> 등에 25억 이상 썼다', 'originallink': 'https://www.khan.co.kr/economy/economy-general/article/202407211426001', 'link': 'https://n.news.naver.com/mnews/article/032/0003309729?sid=101', 'description': '대부분 주민에게 식사와 기념품, <b>여행</b>을 제공하는 데 사용됐다. 한 끼에 850만원이 넘는 금액이 결제되거나, 하루 견학에 쓰인 버스 임차비로 1300만원이 지출된 사례도 있었다. 견학에 참여했던 한 주민은 “스무 명... ', 'pubDate': 'Sun, 21 Jul 2024 14:27:00 +0900'}]}
     json_data = json.dumps(data)
 
-    s3 = boto3.client(
-        "s3",
-        aws_access_key_id=aws_access_key_id, 
-        aws_secret_access_key=aws_secret_access_key
-    )
-    bucket_name = 'brickstudy'
+    s3uploader = S3Uploader()
+
     id = datetime.today().strftime("%Y-%m-%d %H:%M:%S.%f")
-    file_destination=f'travel/bronze/naverAPI/{PLATFROM}/'
-    file_name=f'{PLATFROM}_{QUERY}_{id}'
-    file_key=file_destination+file_name
- 
-    s3.put_object(
-        Bucket=bucket_name, 
-        Key=file_key, 
-        Body=json_data,
-        ContentType='application/json'
+    s3uploader.write_s3(
+        bucket_name='brickstudy',
+        file_key=f'travel/bronze/naverAPI/{PLATFROM}/{PLATFROM}_{QUERY}_{id}',
+        data_type='json',
+        data=json_data
     )
 
-    response = s3.get_object(
-        Bucket=bucket_name,
-        Key=file_key
+    response = s3uploader.s3_client.get_object(
+        Bucket='brickstudy',
+        Key=f'travel/bronze/naverAPI/{PLATFROM}/{PLATFROM}_{QUERY}_{id}'
     )
     content = response['Body'].read().decode('utf-8')
     json_content = json.loads(content)
 
     assert json_content == data
 
-
+#TODO s3_uploader, get_mimetype으로 대체
 def test_s3_uploader_mime_get_right_content_type():
     # given : 올바른 data type
     extension = "json"
     # when : put_object()의 ContentType 옵션에 들어갈 파일 타입 받아오기
     # then : 알맞게 매핑된 ContentType
+    
     content_type = EXTENSION_TO_MIME.get(extension) 
     assert content_type == 'application/json'
 

--- a/brickstudy_ingestion/tests/naver/test_naver_search.py
+++ b/brickstudy_ingestion/tests/naver/test_naver_search.py
@@ -99,9 +99,8 @@ def test_s3_uploader_mime_get_right_content_type():
     extension = "json"
     # when : put_object()의 ContentType 옵션에 들어갈 파일 타입 받아오기
     # then : 알맞게 매핑된 ContentType
-    
-    content_type = EXTENSION_TO_MIME.get(extension) 
-    assert content_type == 'application/json'
+    obj = S3Uploader()
+    assert obj.get_mime_type(extension) == 'application/json'
 
 
 def test_s3_uploader_mime_get_incorrect_content_type():
@@ -110,5 +109,6 @@ def test_s3_uploader_mime_get_incorrect_content_type():
     # when : put_object()의 ContentType 옵션에 들어갈 파일 타입 받아오기
     # then : raise Value Error
     with pytest.raises(ValueError):
-        if extension not in EXTENSION_TO_MIME: 
-            raise ValueError("Unsupported file extension.")
+        obj = S3Uploader()
+        error = obj.get_mime_type(extension)
+        assert error['message'] == "Unsupported file extension."

--- a/brickstudy_ingestion/tests/naver/test_naver_search.py
+++ b/brickstudy_ingestion/tests/naver/test_naver_search.py
@@ -2,7 +2,6 @@ import pytest
 from src.common.errorcode import Naver
 from src.common.exception import ExtractError
 from src.naver.naver_search import NaverSearch
-from src.common.aws_s3_mime import EXTENSION_TO_MIME
 from src.common.s3_uploader import S3Uploader
 
 # Mock
@@ -93,7 +92,7 @@ def test_naver_search_can_connect_to_aws():
 
     assert json_content == data
 
-#TODO s3_uploader, get_mimetype으로 대체
+
 def test_s3_uploader_mime_get_right_content_type():
     # given : 올바른 data type
     extension = "json"

--- a/brickstudy_ingestion/tests/naver/test_naver_search.py
+++ b/brickstudy_ingestion/tests/naver/test_naver_search.py
@@ -106,7 +106,19 @@ def test_naver_search_can_connect_to_aws():
 
 
 def test_s3_uploader_mime_get_right_content_type():
-    
+    # given : 올바른 data type
     extension = "json"
+    # when : put_object()의 ContentType 옵션에 들어갈 파일 타입 받아오기
+    # then : 알맞게 매핑된 ContentType
     content_type = EXTENSION_TO_MIME.get(extension) 
     assert content_type == 'application/json'
+
+
+def test_s3_uploader_mime_get_incorrect_content_type():
+    # given : 올바르지 않은 data type
+    extension = "wrong"
+    # when : put_object()의 ContentType 옵션에 들어갈 파일 타입 받아오기
+    # then : raise Value Error
+    with pytest.raises(ValueError):
+        if extension not in EXTENSION_TO_MIME: 
+            raise ValueError("Unsupported file extension.")

--- a/brickstudy_ingestion/tests/naver/test_naver_search.py
+++ b/brickstudy_ingestion/tests/naver/test_naver_search.py
@@ -2,7 +2,7 @@ import pytest
 from src.common.errorcode import Naver
 from src.common.exception import ExtractError
 from src.naver.naver_search import NaverSearch
-
+from src.common.aws_s3_mime import EXTENSION_TO_MIME
 
 # Mock
 PLATFROM = "news"
@@ -75,6 +75,7 @@ def test_naver_search_can_connect_to_aws():
     # when : request that trying to connect aws
     # then : task success
     data = {'lastBuildDate': 'Sun, 21 Jul 2024 21:14:41 +0900', 'total': 5414727, 'start': 1, 'display': 1, 'items': [{'title': '[단독]한전, 건설지역서 10년간 선심성 식사·<b>여행</b> 등에 25억 이상 썼다', 'originallink': 'https://www.khan.co.kr/economy/economy-general/article/202407211426001', 'link': 'https://n.news.naver.com/mnews/article/032/0003309729?sid=101', 'description': '대부분 주민에게 식사와 기념품, <b>여행</b>을 제공하는 데 사용됐다. 한 끼에 850만원이 넘는 금액이 결제되거나, 하루 견학에 쓰인 버스 임차비로 1300만원이 지출된 사례도 있었다. 견학에 참여했던 한 주민은 “스무 명... ', 'pubDate': 'Sun, 21 Jul 2024 14:27:00 +0900'}]}
+    json_data = json.dumps(data)
 
     s3 = boto3.client(
         "s3",
@@ -90,7 +91,7 @@ def test_naver_search_can_connect_to_aws():
     s3.put_object(
         Bucket=bucket_name, 
         Key=file_key, 
-        Body=json.dumps(data),
+        Body=json_data,
         ContentType='application/json'
     )
 
@@ -102,5 +103,4 @@ def test_naver_search_can_connect_to_aws():
     json_content = json.loads(content)
 
     assert json_content == data
-
 

--- a/brickstudy_ingestion/tests/naver/test_naver_search.py
+++ b/brickstudy_ingestion/tests/naver/test_naver_search.py
@@ -74,8 +74,7 @@ def test_naver_search_can_connect_to_aws():
 
     # when : request that trying to connect aws
     # then : task success
-    client = NaverSearch(PLATFROM, RESPONSE_FORMAT)
-    result = client.request_with_keword(QUERY, DISPLAY, START, SORT)
+    data = {'lastBuildDate': 'Sun, 21 Jul 2024 21:14:41 +0900', 'total': 5414727, 'start': 1, 'display': 1, 'items': [{'title': '[단독]한전, 건설지역서 10년간 선심성 식사·<b>여행</b> 등에 25억 이상 썼다', 'originallink': 'https://www.khan.co.kr/economy/economy-general/article/202407211426001', 'link': 'https://n.news.naver.com/mnews/article/032/0003309729?sid=101', 'description': '대부분 주민에게 식사와 기념품, <b>여행</b>을 제공하는 데 사용됐다. 한 끼에 850만원이 넘는 금액이 결제되거나, 하루 견학에 쓰인 버스 임차비로 1300만원이 지출된 사례도 있었다. 견학에 참여했던 한 주민은 “스무 명... ', 'pubDate': 'Sun, 21 Jul 2024 14:27:00 +0900'}]}
 
     s3 = boto3.client(
         "s3",
@@ -91,8 +90,17 @@ def test_naver_search_can_connect_to_aws():
     s3.put_object(
         Bucket=bucket_name, 
         Key=file_key, 
-        Body=json.dumps(result),
+        Body=json.dumps(data),
         ContentType='application/json'
     )
+
+    response = s3.get_object(
+        Bucket=bucket_name,
+        Key=file_key
+    )
+    content = response['Body'].read().decode('utf-8')
+    json_content = json.loads(content)
+
+    assert json_content == data
 
 

--- a/brickstudy_ingestion/tests/naver/test_naver_search.py
+++ b/brickstudy_ingestion/tests/naver/test_naver_search.py
@@ -61,3 +61,36 @@ def test_naver_search_cannot_connect_client_with_invalid_secret_key():
         assert result["message"] == Naver.AuthError.value["message"]
         # assert result["log"]["errorMessage"] == 'NID AUTH Result Invalid (28) : Authentication failed. (인증에 실패했습니다.)'
         # assert result["log"]["errorCode"] == '024'
+
+
+def test_naver_search_can_connect_to_aws():
+    import os, json
+    from datetime import datetime
+    import boto3
+
+    # given : valid s3 client id, password
+    aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID')
+    aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
+
+    # when : request that trying to connect aws
+    # then : task success
+    client = NaverSearch(PLATFROM, RESPONSE_FORMAT)
+    result = client.request_with_keword(QUERY, DISPLAY, START, SORT)
+
+    s3 = boto3.client(
+        "s3",
+        aws_access_key_id=aws_access_key_id, 
+        aws_secret_access_key=aws_secret_access_key
+    )
+    bucket_name = 'brickstudy'
+    file_destination='travel/bronze/naverAPI/blog/'
+    file_name=f'{PLATFROM}_{QUERY}_{datetime.today().strftime("%Y-%m-%d")}'
+ 
+    s3.put_object(
+        Bucket=bucket_name, 
+        Key=file_destination+file_name, 
+        Body=json.dumps(result),
+        ContentType='application/json'
+    )
+
+

--- a/brickstudy_ingestion/tests/naver/test_naver_search.py
+++ b/brickstudy_ingestion/tests/naver/test_naver_search.py
@@ -104,3 +104,9 @@ def test_naver_search_can_connect_to_aws():
 
     assert json_content == data
 
+
+def test_s3_uploader_mime_get_right_content_type():
+    
+    extension = "json"
+    content_type = EXTENSION_TO_MIME.get(extension) 
+    assert content_type == 'application/json'

--- a/brickstudy_ingestion/tests/naver/test_naver_search.py
+++ b/brickstudy_ingestion/tests/naver/test_naver_search.py
@@ -83,12 +83,14 @@ def test_naver_search_can_connect_to_aws():
         aws_secret_access_key=aws_secret_access_key
     )
     bucket_name = 'brickstudy'
-    file_destination='travel/bronze/naverAPI/blog/'
-    file_name=f'{PLATFROM}_{QUERY}_{datetime.today().strftime("%Y-%m-%d")}'
+    id = datetime.today().strftime("%Y-%m-%d %H:%M:%S.%f")
+    file_destination=f'travel/bronze/naverAPI/{PLATFROM}/'
+    file_name=f'{PLATFROM}_{QUERY}_{id}'
+    file_key=file_destination+file_name
  
     s3.put_object(
         Bucket=bucket_name, 
-        Key=file_destination+file_name, 
+        Key=file_key, 
         Body=json.dumps(result),
         ContentType='application/json'
     )


### PR DESCRIPTION
## description

1. rw 권한 있는 aws 자격증명으로 respond json data를 s3에 write하는 클래스 (S3Uploader) 추가 
2. airflow dag script에 해당 인스턴스 생성 및 데이터 write하는 로직 추가

## further task
1.  해당 PR을 통해 단일 api request를 적재하는 task를 정의한 dag 가 정상적으로 실행되는지 테스트합니다.
    - 이때 필요한 환경변수 (naver api 계정, aws 자격증명) 선언이 필요합니다.
        - web ui 를 통해 airflow configuration 을 설정하는것이 불가합니다.(not exposed)
        - env 파일에 해당 값을 넣고 airflow env 변수로 업로드하는 것은 보안성에서 적절하지 않습니다.
2. 1일 request 쿼터인 25000회에 대해 반복 요청을 테스트합니다.
    - data fetch, s3 access&write 에 network I/O가 있을 것이라 예상합니다.
    - (0) 단순 25000건 반복 실행 퍼포먼스 테스트
    - (1) 25000건을 적절한 배치로(eg. 1000request * 25times) 잘라서 로컬에 buffering하고 있다가 dump로 write
    - (2) ~~25times 반복하는 테스크를 multi threading~~ async http request 